### PR TITLE
fix presets.txt for sol

### DIFF
--- a/src/SplitWireTurkey/Resources/zapret/zapret-winws/presets.txt
+++ b/src/SplitWireTurkey/Resources/zapret/zapret-winws/presets.txt
@@ -1,7 +1,8 @@
 Türk Telekom:--wf-tcp=80,443 --wf-udp=443,50000,50100 --dpi-desync=fake --dpi-desync-ttl=4
 Türk Telekom Alternatif:--wf-tcp=80,443 --wf-udp=443,50000,50100 --dpi-desync=fake --dpi-desync-ttl=3
-SuperOnline:--wf-tcp=80,443 --wf-udp=443,50000,50100 --dpi-desync=fake --dpi-desync-fooling=m5sig
-SuperOnline Alternatif:--wf-tcp=80,443 --wf-udp=443,50000-50099 --dpi-desync=fake --dpi-desync-fooling=m5sig --dpi-desync-ttl=3
+SuperOnline:--wf-tcp=80,443 --wf-udp=443,50000,50100 --dpi-desync=fake --dpi-desync-fooling=md5sig
+SuperOnline Alternatif:--wf-tcp=80,443 --wf-udp=443,50000-50099 --dpi-desync=fake --dpi-desync-fooling=md5sig --dpi-desync-ttl=3
 Kablonet:--wf-tcp=80,443 --wf-udp=443,50000,50100 --dpi-desync=fake --dpi-desync-ttl=4
 Turkcell Hotspot:--wf-tcp=80,443 --wf-udp=443,50000,50100 --dpi-desync=fake --dpi-desync-ttl=1 --dpi-desync-autottl=3
 Vodafone Hotspot:--wf-tcp=80,443 --wf-udp=443,50000,50100 --dpi-desync=multisplit --dpi-desync-split-pos=2
+


### PR DESCRIPTION
superonline presetleri hatalı, `md5sig` olması gereken parametreler yanlışlıkla `m5sig` olarak yazılmış bu sebepten dolayı:

```
Parametreler: --wf-tcp=80,443 --wf-udp=443,50000,50100 --dpi-desync=fake --dpi-desync-fooling=m5sig
self-built version Aug 13 2025 08:46:47

fooling allowed values : none,md5sig,ts,badseq,badsum,datanoack,hopbyhop,hopbyhop2
```

sonuç böyle kalıyor. Düzeltildiği zaman servis düzgün çalışıyor.